### PR TITLE
Bug Fix for handling KEXP playlists with None as the artist or title

### DIFF
--- a/KEX.Py
+++ b/KEX.Py
@@ -119,7 +119,7 @@ class spotify_wrapper:
         try:
             return result['tracks']['items'][0]['id']
         except:
-            return ''
+            return None
 
     def search_playlist(self, title):
         "Find a playlist whose title matches and return its id as a string"
@@ -134,7 +134,7 @@ class spotify_wrapper:
     def playlist_add(self, playlist_id, tracks):
         """Take a list of tracks, and adds them to a given playlist.
         Silently ignore tracks for which we don't have spotify ids (sid)"""
-        tracks = [ track.sid for track in tracks if track.sid is not '' ]
+        tracks = [ track.sid for track in tracks if track.sid is not None ]
         self.sp.user_playlist_add_tracks(self.username, playlist_id, tracks)
 
 class track:


### PR DESCRIPTION
Issue: Encountered a bug where the artist or title were None but they were still getting being included in the tracks array (which was subsequently passed to spotipy on the self.sp.user_playlist_add_tracks).  As a result, Spotipy would error out. 

Example: http://www.kexp.org/playlist/2017/1/11/7PM  (see item at 7:31pm)

Fix: 
Changed how "Missing Tracks" were represented on the tracks array to be consistent with the outcome of the Artist=none and Title=none check.  Rather than use empty string, I opted for the None value. 